### PR TITLE
Add RowArrayAdapter

### DIFF
--- a/src/rowArrayAdapter.ts
+++ b/src/rowArrayAdapter.ts
@@ -13,6 +13,7 @@ export interface RowArrayAdapter {
     min: () => number;
     max: () => number;
     at: (index: number) => SupportedDataPointType;
+    findIndex(test: (any) => boolean): number;
 }
 
 /**
@@ -43,6 +44,7 @@ export class ArrayAsAdapter {
     constructor(array: number[]) {
         this._array = array; // Don't inherit array, we want to fail Array.isArray()
     }
+
     /**
      * Shims the Array.length property
      * @returns the length of the array
@@ -50,6 +52,7 @@ export class ArrayAsAdapter {
     get length(): number {
         return this._array.length;
     }
+
     /**
      * Implements a min() function, in this case a shim over Math.min()
      * @returns the minimum value of the array
@@ -57,13 +60,15 @@ export class ArrayAsAdapter {
     min(): number {
         return Math.min(...this._array);
     } // TODO: I forget if we want value or index
+
     /**
      * Implements a max() function, in this case a shim over Math.max()
      * @returns the maximum value of the array
      */
     max(): number {
         return Math.max(...this._array);
-    } // TODO: ^^
+    } // TODO: Same as above
+
     /**
      * Shims the Array.at() function
      * @param index - the index of the value you'd like to access
@@ -71,5 +76,14 @@ export class ArrayAsAdapter {
      */
     at(index: number): number {
         return this._array.at(index);
+    }
+
+    /**
+     * Shims the Array.findIndex() function, finds index of first element which satisfies the test function
+     * @param test - then function by which we test
+     * @returns index of first element
+     */
+    findIndex(test: (any) => boolean): number {
+        return this._array.findIndex(test);
     }
 }

--- a/src/rowArrayAdapter.ts
+++ b/src/rowArrayAdapter.ts
@@ -9,7 +9,7 @@ import type { SupportedDataPointType } from "./dataPoint";
  * An interface that imitates an array to give c2m read-access to chart data stored elsewhere.
  */
 export interface RowArrayAdapter {
-    length: () => number;
+    length: number;
     min: () => number;
     max: () => number;
     at: (index: number) => SupportedDataPointType;

--- a/src/rowArrayAdapter.ts
+++ b/src/rowArrayAdapter.ts
@@ -4,7 +4,6 @@
 // author: Andrew Pikul (ajpikul@gmail.com)
 
 import type { SupportedDataPointType } from "./dataPoint";
-import { convertDataRow } from "./utils";
 /**
  * An interface that imitates an array to give c2m read-access to chart data stored elsewhere.
  */
@@ -43,8 +42,13 @@ export class ArrayAsAdapter<T extends SupportedDataPointType> {
      * Construct adapter from supplied array
      * @param array - the underlying array from the adapter
      */
-    constructor(array: number[]) {
-        this._array = convertDataRow(array) as T[]; // Don't inherit array, we want to fail Array.isArray()
+    constructor(array: (number | SupportedDataPointType)[]) {
+        // I don't know how c2m handles empty data
+        if (!array) {
+            this._array = [] as T[];
+            return; // This is bad, we should throw an error.
+        }
+        this._array = array as T[]; // Don't inherit array, we want to fail Array.isArray()
     }
 
     /**

--- a/src/rowArrayAdapter.ts
+++ b/src/rowArrayAdapter.ts
@@ -1,0 +1,31 @@
+// The point of rowArrayAdapter is that we don't have to copy data into c2m if a library
+// we're integrating with already stores it differently.
+// TODO: supporting sort/continuous might be a little verbose
+// author: Andrew Pikul (ajpikul@gmail.com)
+
+import type { SupportedDataPointType } from "./dataPoint";
+
+/**
+ * An interface that imitates an array to give c2m read-access to chart data stored elsewhere.
+ */
+export interface RowArrayAdapter {
+    length: () => number;
+    min: () => number;
+    max: () => number;
+    at: (index: number) => SupportedDataPointType;
+}
+
+/**
+ * Check if an object implements the RowArrayAdapter interface.
+ * @param obj - the object to check
+ * @returns true if the object implements the interface
+ */
+export function isRowArrayAdapter(obj: unknown): obj is RowArrayAdapter {
+    return (
+        typeof obj === "object" &&
+        "length" in obj &&
+        "min" in obj &&
+        "max" in obj &&
+        "at" in obj
+    );
+}

--- a/src/rowArrayAdapter.ts
+++ b/src/rowArrayAdapter.ts
@@ -36,15 +36,15 @@ export function isRowArrayAdapter(obj: unknown): obj is RowArrayAdapter {
  * If passed a number array, it will use convertDataRow just like C2M does.
  * If you've already constructed an array of dataPoints, it just wraps it.
  */
-export class ArrayAsAdapter {
-    _array: SupportedDataPointType[];
+export class ArrayAsAdapter<T extends SupportedDataPointType> {
+    _array: T[];
 
     /**
      * Construct adapter from supplied array
      * @param array - the underlying array from the adapter
      */
     constructor(array: number[]) {
-        this._array = convertDataRow(array); // Don't inherit array, we want to fail Array.isArray()
+        this._array = convertDataRow(array) as T[]; // Don't inherit array, we want to fail Array.isArray()
     }
 
     /**
@@ -76,7 +76,7 @@ export class ArrayAsAdapter {
      * @param index - the index of the value you'd like to access
      * @returns the value at the supplied index
      */
-    at(index: number): SupportedDataPointType {
+    at(index: number): T {
         return this._array.at(index);
     }
 
@@ -85,7 +85,7 @@ export class ArrayAsAdapter {
      * @param test - then function by which we test
      * @returns index of first element
      */
-    findIndex(test: (RowArrayAdapter) => boolean): number {
+    findIndex(test: (T) => boolean): number {
         return this._array.findIndex(test);
     }
 }

--- a/src/rowArrayAdapter.ts
+++ b/src/rowArrayAdapter.ts
@@ -23,9 +23,53 @@ export interface RowArrayAdapter {
 export function isRowArrayAdapter(obj: unknown): obj is RowArrayAdapter {
     return (
         typeof obj === "object" &&
-        "length" in obj &&
+        "length" in obj && // TODO: Could, if they give us "length()" instead of "length", we fix it for them?
         "min" in obj &&
         "max" in obj &&
         "at" in obj
     );
+}
+
+/**
+ * Create a RowArrayAdapter from an actual array. This is meant to aid in testing.
+ */
+export class ArrayAsAdapter {
+    _array: number[];
+
+    /**
+     * Construct adapter from supplied array
+     * @param array - the underlying array from the adapter
+     */
+    constructor(array: number[]) {
+        this._array = array; // Don't inherit array, we want to fail Array.isArray()
+    }
+    /**
+     * Shims the Array.length property
+     * @returns the length of the array
+     */
+    get length(): number {
+        return this._array.length;
+    }
+    /**
+     * Implements a min() function, in this case a shim over Math.min()
+     * @returns the minimum value of the array
+     */
+    min(): number {
+        return Math.min(...this._array);
+    } // TODO: I forget if we want value or index
+    /**
+     * Implements a max() function, in this case a shim over Math.max()
+     * @returns the maximum value of the array
+     */
+    max(): number {
+        return Math.max(...this._array);
+    } // TODO: ^^
+    /**
+     * Shims the Array.at() function
+     * @param index - the index of the value you'd like to access
+     * @returns the value at the supplied index
+     */
+    at(index: number): number {
+        return this._array.at(index);
+    }
 }

--- a/src/rowArrayAdapter.ts
+++ b/src/rowArrayAdapter.ts
@@ -4,7 +4,7 @@
 // author: Andrew Pikul (ajpikul@gmail.com)
 
 import type { SupportedDataPointType } from "./dataPoint";
-
+import { convertDataRow } from "./utils";
 /**
  * An interface that imitates an array to give c2m read-access to chart data stored elsewhere.
  */
@@ -33,16 +33,18 @@ export function isRowArrayAdapter(obj: unknown): obj is RowArrayAdapter {
 
 /**
  * Create a RowArrayAdapter from an actual array. This is meant to aid in testing.
+ * If passed a number array, it will use convertDataRow just like C2M does.
+ * If you've already constructed an array of dataPoints, it just wraps it.
  */
 export class ArrayAsAdapter {
-    _array: number[];
+    _array: SupportedDataPointType[];
 
     /**
      * Construct adapter from supplied array
      * @param array - the underlying array from the adapter
      */
     constructor(array: number[]) {
-        this._array = array; // Don't inherit array, we want to fail Array.isArray()
+        this._array = convertDataRow(array); // Don't inherit array, we want to fail Array.isArray()
     }
 
     /**
@@ -58,23 +60,23 @@ export class ArrayAsAdapter {
      * @returns the minimum value of the array
      */
     min(): number {
-        return Math.min(...this._array);
-    } // TODO: I forget if we want value or index
+        return 0; // TODO implement when necessary
+    }
 
     /**
      * Implements a max() function, in this case a shim over Math.max()
      * @returns the maximum value of the array
      */
     max(): number {
-        return Math.max(...this._array);
-    } // TODO: Same as above
+        return 0; // TODO implement when necessary
+    }
 
     /**
      * Shims the Array.at() function
      * @param index - the index of the value you'd like to access
      * @returns the value at the supplied index
      */
-    at(index: number): number {
+    at(index: number): SupportedDataPointType {
         return this._array.at(index);
     }
 
@@ -83,7 +85,7 @@ export class ArrayAsAdapter {
      * @param test - then function by which we test
      * @returns index of first element
      */
-    findIndex(test: (any) => boolean): number {
+    findIndex(test: (RowArrayAdapter) => boolean): number {
         return this._array.findIndex(test);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 import type { AudioEngine } from "./audio/";
 import type { c2m } from "./c2mChart";
 import type { SupportedDataPointType } from "./dataPoint";
+import type { RowArrayAdapter } from "./rowArrayAdapter";
 
 /**
  * Details for a given hotkey
@@ -71,7 +72,7 @@ export type SonifyTypes = {
      * The data that should be presented in this chart.
      * This key is required for all charts.
      */
-    data: dataSet | SupportedInputType[];
+    data: dataSet | SupportedInputType[] | RowArrayAdapter;
     /**
      * The HTML element in the DOM that represents this chart.
      * This will be used to handle keyboard events to enable the user to interact with the chart.
@@ -111,7 +112,7 @@ export type SonifyTypes = {
  * A dictionary of data, where the key is the group name, and the value is the array of data points
  */
 export type dataSet = {
-    [groupName: string]: SupportedInputType[] | null;
+    [groupName: string]: SupportedInputType[] | RowArrayAdapter | null;
 };
 
 /**

--- a/test/_adapter_utilities.ts
+++ b/test/_adapter_utilities.ts
@@ -1,0 +1,36 @@
+import type { SupportedDataPointType } from "../src/dataPoint";
+import * as adapter from "../src/rowArrayAdapter";
+
+export const probabilities = [
+    0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1
+];
+
+/**
+ * AdapterTypeRandomizer provides a way to fuzz test, switching
+ * between regular arrays and adapters.
+ */
+export class AdapterTypeRandomizer<T extends SupportedDataPointType> {
+    proportion: number;
+
+    /**
+     * constructor to set relative proportions
+     * @param proportion - how often should the input be wrapped in a adapter
+     */
+    constructor(proportion: number | undefined) {
+        this.proportion = proportion || 0.5;
+    }
+
+    /**
+     * a is the wrapper fucntion for arrays, it might return the equivalent adapter
+     * @param a - the array you want to wrap
+     * @returns either a or a wrapped a
+     */
+    a(a: number[]): number[] | adapter.RowArrayAdapter {
+        //console.log(a);
+        const flip = Math.random();
+        //console.log(`if (${flip} < ${this.proportion}) adapt!`);
+        if (flip < this.proportion) return new adapter.ArrayAsAdapter<T>(a);
+        //console.log(`Not wrapped, returning: ${a}`);
+        return a;
+    }
+}

--- a/test/rowArrayAdapter.test.ts
+++ b/test/rowArrayAdapter.test.ts
@@ -1,0 +1,16 @@
+import * as adapter from "../src/rowArrayAdapter";
+
+test("test if functions return the correct value", () => {
+    const x = [1, 2, 3, 4];
+    expect(adapter.isRowArrayAdapter(x)).toBeFalsy();
+
+    const xAdapter = new adapter.ArrayAsAdapter(x);
+    expect(adapter.isRowArrayAdapter(xAdapter)).toBeTruthy();
+    expect(xAdapter.length).toBe(x.length);
+    expect(xAdapter.min()).toBe(Math.min(...x));
+    expect(xAdapter.max()).toBe(Math.max(...x));
+    x.forEach((el, i) => {
+        expect(xAdapter.at(i)).toBe(el);
+    });
+    expect(xAdapter.length).toBe(x.length);
+});

--- a/test/rowArrayAdapter.test.ts
+++ b/test/rowArrayAdapter.test.ts
@@ -1,6 +1,6 @@
 import * as adapter from "../src/rowArrayAdapter";
 
-test("test if functions return the correct value", () => {
+test("test if ArrayAsAdapter successful constructs a proper RowArrayAdapter", () => {
     const x = [1, 2, 3, 4];
     expect(adapter.isRowArrayAdapter(x)).toBeFalsy();
 
@@ -12,5 +12,16 @@ test("test if functions return the correct value", () => {
     x.forEach((el, i) => {
         expect(xAdapter.at(i)).toBe(el);
     });
-    expect(xAdapter.length).toBe(x.length);
+    x.forEach((el, i) => {
+        expect(
+            xAdapter.findIndex((el2) => {
+                return el2 === el;
+            })
+        ).toBe(i);
+        expect(
+            xAdapter.findIndex(() => {
+                return false;
+            })
+        ).toBe(-1);
+    });
 });

--- a/test/rowArrayAdapter.test.ts
+++ b/test/rowArrayAdapter.test.ts
@@ -1,10 +1,11 @@
 import * as adapter from "../src/rowArrayAdapter";
+import type { SimpleDataPoint } from "../src/dataPoint";
 
 test("test if ArrayAsAdapter successful constructs a proper RowArrayAdapter", () => {
     const x = [1, 2, 3, 4];
     expect(adapter.isRowArrayAdapter(x)).toBeFalsy();
 
-    const xAdapter = new adapter.ArrayAsAdapter(x);
+    const xAdapter = new adapter.ArrayAsAdapter<SimpleDataPoint>(x);
     expect(adapter.isRowArrayAdapter(xAdapter)).toBeTruthy();
     expect(xAdapter.length).toBe(x.length);
     // expect(xAdapter.min()).toBe(Math.min(...x)); // not yet
@@ -15,8 +16,7 @@ test("test if ArrayAsAdapter successful constructs a proper RowArrayAdapter", ()
     });
     x.forEach((el, i) => {
         expect(
-            xAdapter.findIndex((el2: adapter.RowArrayAdapter) => {
-                if (!el2) return false;
+            xAdapter.findIndex((el2: SimpleDataPoint) => {
                 return el2.y === el;
             })
         ).toBe(i);

--- a/test/rowArrayAdapter.test.ts
+++ b/test/rowArrayAdapter.test.ts
@@ -7,15 +7,17 @@ test("test if ArrayAsAdapter successful constructs a proper RowArrayAdapter", ()
     const xAdapter = new adapter.ArrayAsAdapter(x);
     expect(adapter.isRowArrayAdapter(xAdapter)).toBeTruthy();
     expect(xAdapter.length).toBe(x.length);
-    expect(xAdapter.min()).toBe(Math.min(...x));
-    expect(xAdapter.max()).toBe(Math.max(...x));
+    // expect(xAdapter.min()).toBe(Math.min(...x)); // not yet
+    // expect(xAdapter.max()).toBe(Math.max(...x)); // not yet
     x.forEach((el, i) => {
-        expect(xAdapter.at(i)).toBe(el);
+        expect(xAdapter.at(i).y).toBe(el);
+        expect(xAdapter.at(i).x).toBe(i);
     });
     x.forEach((el, i) => {
         expect(
-            xAdapter.findIndex((el2) => {
-                return el2 === el;
+            xAdapter.findIndex((el2: adapter.RowArrayAdapter) => {
+                if (!el2) return false;
+                return el2.y === el;
             })
         ).toBe(i);
         expect(

--- a/test/rowArrayAdapter.test.ts
+++ b/test/rowArrayAdapter.test.ts
@@ -1,11 +1,14 @@
 import * as adapter from "../src/rowArrayAdapter";
 import type { SimpleDataPoint } from "../src/dataPoint";
+import { convertDataRow } from "../src/utils";
 
 test("test if ArrayAsAdapter successful constructs a proper RowArrayAdapter", () => {
     const x = [1, 2, 3, 4];
     expect(adapter.isRowArrayAdapter(x)).toBeFalsy();
 
-    const xAdapter = new adapter.ArrayAsAdapter<SimpleDataPoint>(x);
+    const xAdapter = new adapter.ArrayAsAdapter<SimpleDataPoint>(
+        convertDataRow(x)
+    );
     expect(adapter.isRowArrayAdapter(xAdapter)).toBeTruthy();
     expect(xAdapter.length).toBe(x.length);
     // expect(xAdapter.min()).toBe(Math.min(...x)); // not yet

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -14,6 +14,8 @@ import {
     validateInputTypeCountsMatchData
 } from "../src/validate";
 
+import { AdapterTypeRandomizer, probabilities } from "./_adapter_utilities";
+
 const validTypes =
     "line, bar, band, pie, candlestick, histogram, box, matrix, scatter, treemap, unsupported";
 const validLanguages = "en, de, es, fr, it";
@@ -148,9 +150,12 @@ test("validateInput", () => {
     );
 });
 
-test("validateInputDataRowHomogeneity", () => {
+test.each(probabilities)("validateInputDataRowHomogeneity", (p) => {
+    const s = new AdapterTypeRandomizer<SimpleDataPoint>(p);
+    const y2 = new AdapterTypeRandomizer<AlternativeAxisDataPoint>(p);
+
     // Confirm number homogeneity
-    expect(validateInputDataRowHomogeneity([1, 2, 3, 4, 5])).toBe("");
+    expect(validateInputDataRowHomogeneity(s.a([1, 2, 3, 4, 5]))).toBe("");
 
     // @ts-ignore - deliberately generating error condition
     // Invalidate on number heterogeneity
@@ -160,188 +165,262 @@ test("validateInputDataRowHomogeneity", () => {
 
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 1, y: 1 },
-            { x: 2, y: 2 },
-            { x: 3, y: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            s.a([
+                { x: 1, y: 1 },
+                { x: 2, y: 2 },
+                { x: 3, y: 3 }
+            ])
+        )
     ).toBe("");
     // Confirm simple data point homogeneity
     expect(
         validateInputDataRowHomogeneity([{ x: 1, y: 1 }, { x: 2, y: 2 }, 3])
     ).toBe(
         `The first item is a simple data point (x/y), but item index 2 is not (value: 3). All items should be of the same type.`
-    );
+    ); // wrapping in adapter would fix this error
 
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 1, y2: 1 },
-            { x: 2, y2: 2 },
-            { x: 3, y2: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            y2.a([
+                { x: 1, y2: 1 },
+                { x: 2, y2: 2 },
+                { x: 3, y2: 3 }
+            ])
+        )
     ).toBe("");
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 1, y2: 1 },
-            { x: 2, y: 2 },
-            { x: 3, y2: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            y2.a([
+                { x: 1, y2: 1 },
+                { x: 2, y: 2 },
+                { x: 3, y2: 3 }
+            ])
+        )
     ).toBe(
         `The first item is an alternate axis data point (x/y2), but item index 1 is not (value: {"x":2,"y":2}). All items should be of the same type.`
     );
 
+    const hl = new AdapterTypeRandomizer<HighLowDataPoint>(p);
+
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 1, high: 1, low: 1 },
-            { x: 2, high: 2, low: 2 },
-            { x: 3, high: 3, low: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            hl.a([
+                { x: 1, high: 1, low: 1 },
+                { x: 2, high: 2, low: 2 },
+                { x: 3, high: 3, low: 3 }
+            ])
+        )
     ).toBe("");
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 1, high: 1, low: 1 },
-            { x: 2, y: 2 },
-            { x: 3, y2: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            hl.a([
+                { x: 1, high: 1, low: 1 },
+                { x: 2, y: 2 },
+                { x: 3, y2: 3 }
+            ])
+        )
     ).toBe(
         `The first item is a high low data point (x/high/low), but item index 1 is not (value: {"x":2,"y":2}). All items should be of the same type.`
     );
 
+    const ohlc = new AdapterTypeRandomizer<OHLCDataPoint>(p);
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 1, open: 1, high: 1, low: 1, close: 1 },
-            { x: 2, open: 2, high: 2, low: 2, close: 2 },
-            { x: 3, open: 3, high: 3, low: 3, close: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            ohlc.a([
+                { x: 1, open: 1, high: 1, low: 1, close: 1 },
+                { x: 2, open: 2, high: 2, low: 2, close: 2 },
+                { x: 3, open: 3, high: 3, low: 3, close: 3 }
+            ])
+        )
     ).toBe("");
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 1, high: 1, low: 1, open: 1, close: 1 },
-            { x: 2, high: 2, low: 1 },
-            { x: 3, y2: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            ohlc.a([
+                { x: 1, high: 1, low: 1, open: 1, close: 1 },
+                { x: 2, high: 2, low: 1 },
+                { x: 3, y2: 3 }
+            ])
+        )
     ).toBe(
         `The first item is an OHLC data point (x/open/high/low/close), but item index 1 is not (value: {"x":2,"high":2,"low":1}). All items should be of the same type.`
     );
 
+    const box = new AdapterTypeRandomizer<BoxDataPoint>(p);
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 0, low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53 },
-            { x: 1, low: 7.1, q1: 7.18, median: 7.25, q3: 7.33, high: 7.4 },
-            { x: 2, low: 7.31, q1: 7.32, median: 7.32, q3: 7.33, high: 7.33 }
-        ])
+        validateInputDataRowHomogeneity(
+            box.a([
+                {
+                    x: 0,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53
+                },
+                { x: 1, low: 7.1, q1: 7.18, median: 7.25, q3: 7.33, high: 7.4 },
+                {
+                    x: 2,
+                    low: 7.31,
+                    q1: 7.32,
+                    median: 7.32,
+                    q3: 7.33,
+                    high: 7.33
+                }
+            ])
+        )
     ).toBe("");
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 0, low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53 },
-            { x: 2, high: 2, low: 1 },
-            { x: 3, y2: 3 }
-        ])
+        validateInputDataRowHomogeneity(
+            box.a([
+                {
+                    x: 0,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53
+                },
+                { x: 2, high: 2, low: 1 },
+                { x: 3, y2: 3 }
+            ])
+        )
     ).toBe(
         `The first item is a box data point (x/low/q1/median/q3/high), but item index 1 is not (value: {"x":2,"high":2,"low":1}). All items should be of the same type.`
     );
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 0, low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53 },
-            {
-                x: 1,
-                low: 5.03,
-                q1: 6.36,
-                median: 6.91,
-                q3: 7.34,
-                high: 7.53,
-                // @ts-ignore: Deliberately using invalid data in order to test error handling
-                outlier: null
-            }
-        ])
+        validateInputDataRowHomogeneity(
+            box.a([
+                {
+                    x: 0,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53
+                },
+                {
+                    x: 1,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53,
+                    // @ts-ignore: Deliberately using invalid data in order to test error handling
+                    outlier: null
+                }
+            ])
+        )
     ).toBe(
         `At least one box provided an outlier that was not an array. An outliers should be an array of numbers. The box is question is: {"x":1,"low":5.03,"q1":6.36,"median":6.91,"q3":7.34,"high":7.53,"outlier":null}`
     );
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 0, low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53 },
-            {
-                x: 1,
-                low: 5.03,
-                q1: 6.36,
-                median: 6.91,
-                q3: 7.34,
-                high: 7.53,
-                // @ts-ignore: Deliberately using invalid data in order to test error handling
-                outlier: 5
-            }
-        ])
+        validateInputDataRowHomogeneity(
+            box.a([
+                {
+                    x: 0,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53
+                },
+                {
+                    x: 1,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53,
+                    // @ts-ignore: Deliberately using invalid data in order to test error handling
+                    outlier: 5
+                }
+            ])
+        )
     ).toBe(
         `At least one box provided an outlier that was not an array. An outliers should be an array of numbers. The box is question is: {"x":1,"low":5.03,"q1":6.36,"median":6.91,"q3":7.34,"high":7.53,"outlier":5}`
     );
     expect(
-        validateInputDataRowHomogeneity([
-            { x: 0, low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53 },
-            {
-                x: 1,
-                low: 5.03,
-                q1: 6.36,
-                median: 6.91,
-                q3: 7.34,
-                high: 7.53,
-                outlier: [5]
-            },
-            {
-                x: 2,
-                low: 5.03,
-                q1: 6.36,
-                median: 6.91,
-                q3: 7.34,
-                high: 7.53,
-                // @ts-ignore: Deliberately using invalid data in order to test error handling
-                outlier: [5, null]
-            }
-        ])
+        validateInputDataRowHomogeneity(
+            box.a([
+                {
+                    x: 0,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53
+                },
+                {
+                    x: 1,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53,
+                    outlier: [5]
+                },
+                {
+                    x: 2,
+                    low: 5.03,
+                    q1: 6.36,
+                    median: 6.91,
+                    q3: 7.34,
+                    high: 7.53,
+                    // @ts-ignore: Deliberately using invalid data in order to test error handling
+                    outlier: [5, null]
+                }
+            ])
+        )
     ).toBe(
         `At least one box has a non-numeric outlier. Box outliers must be an array of numbers. The box in question is: {"x":2,"low":5.03,"q1":6.36,"median":6.91,"q3":7.34,"high":7.53,"outlier":[5,null]}`
     );
 
     // @ts-ignore - deliberately generating error condition
     // Confirm number homogeneity
-    expect(validateInputDataRowHomogeneity(["1", 2, 3, 4, 5])).toBe(
+    expect(validateInputDataRowHomogeneity(s.a(["1", 2, 3, 4, 5]))).toBe(
         `The first item is of an unrecognized type (value: "1"). Supported types are: number, simple data point (x/y), alternative axis data point (x/y2), and high low data point (x/high/low).`
     );
 
     expect(
-        validateInputDataRowHomogeneity([
-            // @ts-ignore
-            { x: new Date(), y: 1 }
-        ])
+        validateInputDataRowHomogeneity(
+            s.a([
+                // @ts-ignore
+                { x: new Date(), y: 1 }
+            ])
+        )
     ).toContain(
         "The first item is a date, which is not a supported format type"
     );
 });
 
-test("validateInputDataHomogeneity", () => {
+test.each(probabilities)("validateInputDataHomogeneity", (p) => {
+    const s = new AdapterTypeRandomizer<SimpleDataPoint>(p);
+    const y2 = new AdapterTypeRandomizer<AlternativeAxisDataPoint>(p);
     // Good, 1 row
-    expect(validateInputDataHomogeneity([1, 2, 3, 4, 5])).toBe("");
+    expect(validateInputDataHomogeneity(s.a([1, 2, 3, 4, 5]))).toBe("");
 
     // Good, multiple rows
     expect(
         validateInputDataHomogeneity({
-            a: [
+            a: s.a([
                 { x: 1, y: 1 },
                 { x: 2, y: 2 },
                 { x: 3, y: 3 }
-            ],
-            b: [
+            ]),
+            b: y2.a([
                 { x: 1, y2: 1 },
                 { x: 2, y2: 2 },
                 { x: 3, y2: 3 }
-            ]
+            ])
         })
     ).toBe("");
 
@@ -349,21 +428,21 @@ test("validateInputDataHomogeneity", () => {
     // Bad, 1 row
     expect(validateInputDataRowHomogeneity([1, 2, "a", 4, 5])).toBe(
         `The first item is a number, but item index 2 is not (value: "a"). All items should be of the same type.`
-    );
+    ); // Error changes on type, so we don't use our type randomizer
 
     // Bad, multiple rows
     expect(
         validateInputDataHomogeneity({
-            a: [
+            a: s.a([
                 { x: 1, y: 1 },
                 { x: 2, y: 2 },
                 { x: 3, y: 3 }
-            ],
-            b: [
+            ]),
+            b: y2.a([
                 { x: 1, y2: 1 },
                 { x: 2, y: 2 },
                 { x: 3, y2: 3 }
-            ]
+            ])
         })
     ).toBe(
         `Error for data category b: The first item is an alternate axis data point (x/y2), but item index 1 is not (value: {"x":2,"y":2}). All items should be of the same type.`
@@ -371,11 +450,11 @@ test("validateInputDataHomogeneity", () => {
 
     expect(
         validateInputDataHomogeneity({
-            a: [
+            a: s.a([
                 { x: 1, y: 1 },
                 { x: 2, y: 2 },
                 { x: 3, y: 3 }
-            ],
+            ]),
             b: null
         })
     ).toBe("");
@@ -401,13 +480,14 @@ test("validate img tag without cc property", () => {
     );
 });
 
-test("validateHierarchyReferences", () => {
+test.each(probabilities)("validateHierarchyReferences", (p) => {
+    const s = new AdapterTypeRandomizer<SimpleDataPoint>(p);
     // happy path
     expect(
         validateHierarchyReferences(
             {
-                a: [{ x: 0, y: 1, children: "b" }],
-                b: [{ x: 1, y: 2 }]
+                a: s.a([{ x: 0, y: 1, children: "b" }]),
+                b: s.a([{ x: 1, y: 2 }])
             },
             { root: "a" }
         )
@@ -417,19 +497,19 @@ test("validateHierarchyReferences", () => {
     expect(
         validateHierarchyReferences(
             {
-                a: [{ x: 0, y: 1 }],
-                b: [{ x: 1, y: 2 }]
+                a: s.a([{ x: 0, y: 1 }]),
+                b: s.a([{ x: 1, y: 2 }])
             },
             { root: "a" }
         )
     ).toBe("");
 
     // data = number[], options = undefined
-    expect(validateHierarchyReferences([1, 2, 3, 4, 5])).toBe("");
+    expect(validateHierarchyReferences(s.a([1, 2, 3, 4, 5]))).toBe("");
 
     // data = number[], options = {root}}
     expect(
-        validateHierarchyReferences([1, 2, 3, 4, 5], { root: "a" })
+        validateHierarchyReferences(s.a([1, 2, 3, 4, 5]), { root: "a" })
     ).toContain(
         `Unexpected data structure. options.root="a", but "a" is not a key in data.`
     );
@@ -438,8 +518,8 @@ test("validateHierarchyReferences", () => {
     expect(() =>
         validateHierarchyReferences(
             {
-                a: [1, 2, 3, 4, 5],
-                b: [6, 7, 8]
+                a: s.a([1, 2, 3, 4, 5]),
+                b: s.a([6, 7, 8])
             },
             { root: "a" }
         )
@@ -458,21 +538,21 @@ test("validateHierarchyReferences", () => {
     ).not.toThrow();
 
     // data = {key: number[]}, options = undefined
-    expect(validateHierarchyReferences({ a: [1, 2, 3, 4, 5] })).toBe("");
+    expect(validateHierarchyReferences({ a: s.a([1, 2, 3, 4, 5]) })).toBe("");
 
     // data = { key: {x,y}[] }, options = undefined
     expect(
         validateHierarchyReferences({
-            a: [{ x: 0, y: 1 }],
-            b: [{ x: 1, y: 2 }]
+            a: s.a([{ x: 0, y: 1 }]),
+            b: s.a([{ x: 1, y: 2 }])
         })
     ).toBe("");
 
     // data = tree, options = {}
     expect(
         validateHierarchyReferences({
-            a: [{ x: 0, y: 1, children: "b" }],
-            b: [{ x: 1, y: 2 }]
+            a: s.a([{ x: 0, y: 1, children: "b" }]),
+            b: s.a([{ x: 1, y: 2 }])
         })
     ).toBe("");
 
@@ -480,8 +560,8 @@ test("validateHierarchyReferences", () => {
     expect(
         validateHierarchyReferences(
             {
-                a: [{ x: 0, y: 1, children: "b" }],
-                b: [{ x: 1, y: 2 }]
+                a: s.a([{ x: 0, y: 1, children: "b" }]),
+                b: s.a([{ x: 1, y: 2 }])
             },
             { root: "z" }
         )
@@ -493,8 +573,8 @@ test("validateHierarchyReferences", () => {
     expect(
         validateHierarchyReferences(
             {
-                a: [{ x: 0, y: 1, children: "a" }],
-                b: [{ x: 1, y: 2 }]
+                a: s.a([{ x: 0, y: 1, children: "a" }]),
+                b: s.a([{ x: 1, y: 2 }])
             },
             { root: "a" }
         )
@@ -506,8 +586,8 @@ test("validateHierarchyReferences", () => {
     expect(
         validateHierarchyReferences(
             {
-                a: [{ x: 0, y: 1, children: "z" }],
-                b: [{ x: 1, y: 2 }]
+                a: s.a([{ x: 0, y: 1, children: "z" }]),
+                b: s.a([{ x: 1, y: 2 }])
             },
             { root: "a" }
         )
@@ -519,8 +599,8 @@ test("validateHierarchyReferences", () => {
     expect(
         validateHierarchyReferences(
             {
-                a: [{ x: 0, y: 1, children: "b" }],
-                b: [{ x: 1, y: 2, children: "a" }]
+                a: s.a([{ x: 0, y: 1, children: "b" }]),
+                b: s.a([{ x: 1, y: 2, children: "a" }])
             },
             { root: "a" }
         )
@@ -533,8 +613,8 @@ test("validateHierarchyReferences", () => {
         validateHierarchyReferences(
             {
                 // @ts-ignore
-                a: [{ x: 0, y: 1, children: 1 }],
-                b: [{ x: 1, y: 2 }]
+                a: s.a([{ x: 0, y: 1, children: 1 }]),
+                b: s.a([{ x: 1, y: 2 }])
             },
             { root: "a" }
         )
@@ -543,10 +623,11 @@ test("validateHierarchyReferences", () => {
     );
 });
 
-test("validateInputTypeCountsMatchData", () => {
+test.each(probabilities)("validateInputTypeCountsMatchData", (p) => {
+    const s = new AdapterTypeRandomizer<SimpleDataPoint>(p);
     const dataWith2Rows = {
-        A: [1, 2, 3],
-        B: [4, 5, 6]
+        A: s.a([1, 2, 3]),
+        B: s.a([4, 5, 6])
     };
 
     expect(

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -176,10 +176,12 @@ test.each(probabilities)("validateInputDataRowHomogeneity", (p) => {
     ).toBe("");
     // Confirm simple data point homogeneity
     expect(
-        validateInputDataRowHomogeneity([{ x: 1, y: 1 }, { x: 2, y: 2 }, 3])
+        validateInputDataRowHomogeneity(
+            s.a([{ x: 1, y: 1 }, { x: 2, y: 2 }, 3])
+        )
     ).toBe(
         `The first item is a simple data point (x/y), but item index 2 is not (value: 3). All items should be of the same type.`
-    ); // wrapping in adapter would fix this error!
+    );
 
     // Confirm simple data point homogeneity
     expect(

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -151,6 +151,7 @@ test("validateInput", () => {
 });
 
 test.each(probabilities)("validateInputDataRowHomogeneity", (p) => {
+    const n = new AdapterTypeRandomizer<number>(p);
     const s = new AdapterTypeRandomizer<SimpleDataPoint>(p);
     const y2 = new AdapterTypeRandomizer<AlternativeAxisDataPoint>(p);
 
@@ -159,9 +160,9 @@ test.each(probabilities)("validateInputDataRowHomogeneity", (p) => {
 
     // @ts-ignore - deliberately generating error condition
     // Invalidate on number heterogeneity
-    expect(validateInputDataRowHomogeneity([1, 2, "a", 4, 5])).toBe(
+    expect(validateInputDataRowHomogeneity(n.a([1, 2, "a", 4, 5]))).toBe(
         `The first item is a number, but item index 2 is not (value: "a"). All items should be of the same type.`
-    );
+    ); // To keep typing simpler, adapters don't replace actual native arrays like number[], they will always
 
     // Confirm simple data point homogeneity
     expect(
@@ -178,7 +179,7 @@ test.each(probabilities)("validateInputDataRowHomogeneity", (p) => {
         validateInputDataRowHomogeneity([{ x: 1, y: 1 }, { x: 2, y: 2 }, 3])
     ).toBe(
         `The first item is a simple data point (x/y), but item index 2 is not (value: 3). All items should be of the same type.`
-    ); // wrapping in adapter would fix this error
+    ); // wrapping in adapter would fix this error!
 
     // Confirm simple data point homogeneity
     expect(


### PR DESCRIPTION
Hi,

This is the start of an experimental feature that allow developers of visual chart libraries to, instead of copying data into a `c2m` handle, give `c2m` a read-only view into the memory object of the original visual chart library.

The benefits are

a) Reducing memory (RAM) usage by an order of magnitude
b) Clearly delineating which code controls the data
c) Relatively small addition (<<6kB full size)

### Concept

For example, to store data, `plotly` uses a dictionary of arrays `{ x:[], y:[] }`, and `c2m` uses an array of dictionaries  `[ {x:, y:}, {x:, y:} ]`. The current solution is to create a new `c2m` style object containing a copy of all data, but this adapter allows us to create a class that will return a `c2m` style object upon request without copying and transforming  the entire `plotly` object.

### Challenges

The only downside is that `c2m` expects full access to the native arrays, but we can't override the index operator `[]`. Luckily, all arrays support `.at()` as a synonym, and we can override that. But whenever `c2m` wants to index into a row, it has to use `.at()`, not `[]`, since the adapter is not a real array, it is just array-like access to another object.

### Testing

My solution for testing, since the adapter should work anywhere a `(number | SupportedDataPointType)[]` does, is to randomly wrap test data in the adapter w/o changing any test parameters.  Tests where this is necessary are then parameterized to be run N times w/ frequency of data-wrapping increasing. Every possible mixture of types should work with the adapter. This testing could be pared down with maturity.

**TODO**
- [ ] utils.ts
- [ ] c2mChart.ts
- [ ] search for more row access
- [ ] continuous mode will probs be solved w/ a b-tree index instead of sorting the original array. Better for live data anyway. Investigate.