### PR TITLE
Add class names to dialogs

### DIFF
--- a/src/infoDialog.ts
+++ b/src/infoDialog.ts
@@ -10,6 +10,8 @@ const toHtmlEntities = (str: string) => {
 
 export const launchInfoDialog = (info: c2mInfo, language: string) => {
     const dialog = document.createElement("dialog");
+    dialog.classList.add("chart2music-dialog");
+    dialog.classList.add("chart2music-info-dialog");
     dialog.setAttribute("aria-label", translate(language, "info-title"));
     let content = `<h1 tabIndex='0'>${translate(language, "info-title")}</h1>`;
 

--- a/src/keyboardManager.ts
+++ b/src/keyboardManager.ts
@@ -101,6 +101,8 @@ export class KeyboardEventManager {
      */
     generateHelpDialog(lang: string) {
         const dialog = document.createElement("dialog");
+        dialog.classList.add("chart2music-dialog");
+        dialog.classList.add("chart2music-help-dialog");
         dialog.setAttribute("lang", lang);
 
         const closeButton = document.createElement("button");

--- a/src/optionDialog.ts
+++ b/src/optionDialog.ts
@@ -27,6 +27,8 @@ export const launchOptionDialog = (
     playCb?: (hertz: number) => void
 ) => {
     const dialog = document.createElement("dialog");
+    dialog.classList.add("chart2music-dialog");
+    dialog.classList.add("chart2music-option-dialog");
     dialog.setAttribute("lang", language);
     dialog.setAttribute("aria-label", translate(language, "options-title"));
     dialog.innerHTML = `<h1>${translate(language, "options-title")}</h1>


### PR DESCRIPTION
Add class names to dialogs. All dialogs will have the class name `chart2music-dialog`, and each dialog also gets its own class name: `chart2music-help-dialog`, `chart2music-info-dialog`, and `chart2music-option-dialog`.