### PR TITLE
Add translation support for customizable point descriptions

### DIFF
--- a/src/c2mChart.ts
+++ b/src/c2mChart.ts
@@ -243,6 +243,11 @@ export class c2m {
                 this._translator.intercepterCallback =
                     input.options.translationCallback;
             }
+
+            if (input.options.announcePointLabelFirst) {
+                this._announcePointLabelFirst =
+                    input.options.announcePointLabelFirst;
+            }
         }
 
         prepChartElement({
@@ -768,7 +773,7 @@ export class c2m {
     private _createFrequencyTable(
         rowFilter?: (row: SupportedDataPointType[], rowIndex: number) => boolean
     ): SimpleDataPoint[] {
-        const freqTable = {};
+        const freqTable: Record<number, number> = {};
         this._data.forEach((row, rowIndex) => {
             if (rowFilter && !rowFilter(row, rowIndex)) {
                 return;
@@ -783,8 +788,11 @@ export class c2m {
                 freqTable[cell.x] += cell.y;
             });
         });
-        return Object.entries(freqTable).map(([x, y]) => {
-            return { x: Number(x), y } as SimpleDataPoint;
+        return Object.entries(freqTable).map(([x, total]) => {
+            return {
+                x: Number(x),
+                y: total
+            } as SimpleDataPoint;
         });
     }
 
@@ -2392,7 +2400,9 @@ export class c2m {
             }),
             stat: availableStats[statIndex],
             outlierIndex: this._outlierMode ? this._outlierIndex : null,
-            announcePointLabelFirst: this._announcePointLabelFirst
+            announcePointLabelFirst: this._announcePointLabelFirst,
+            pointIndex: this._pointIndex,
+            groupIndex: this._groupIndex
         });
 
         const text = filteredJoin(

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -123,12 +123,14 @@ const dictionary: translationDict = {
     "stat-outlier": "Ausreisser",
 
     "point-xy": "{x}, {y}",
+    "point-xy-label":
+        "{announcePointLabelFirst, select, true {{label}, {x}, {y}} other {{x}, {y}, {label}}}",
     "point-xohlc": "{x}, {open} - {high} - {low} - {close}",
     "point-outlier": "{x}, {y}, {index} von {count}",
     "point-xhl": "{x}, {high} - {low}",
-    "point-xhl-outlier": `{x}, {high} - {low}, mit {count, plural, 
-        =0 {keinem Ausreisser} 
-        one {{count} Ausreisser} 
+    "point-xhl-outlier": `{x}, {high} - {low}, mit {count, plural,
+        =0 {keinem Ausreisser}
+        one {{count} Ausreisser}
         other {{count} Ausreissern}
     }`,
 

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -115,12 +115,14 @@ const dictionary: translationDict = {
     "stat-outlier": "Outlier",
 
     "point-xy": "{x}, {y}",
+    "point-xy-label":
+        "{announcePointLabelFirst, select, true {{label}, {x}, {y}} other {{x}, {y}, {label}}}",
     "point-xohlc": "{x}, {open} - {high} - {low} - {close}",
     "point-outlier": "{x}, {y}, {index} of {count}",
     "point-xhl": "{x}, {high} - {low}",
-    "point-xhl-outlier": `{x}, {high} - {low}, with {count, plural, 
-        =0 {no outliers} 
-        one {{count} outlier} 
+    "point-xhl-outlier": `{x}, {high} - {low}, with {count, plural,
+        =0 {no outliers}
+        one {{count} outlier}
         other {{count} outliers}
     }`,
 

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -116,12 +116,14 @@ const dictionary: translationDict = {
     "stat-outlier": "Valor Atípico",
 
     "point-xy": "{x}, {y}",
+    "point-xy-label":
+        "{announcePointLabelFirst, select, true {{label}, {x}, {y}} other {{x}, {y}, {label}}}",
     "point-xohlc": "{x}, {open} - {high} - {low} - {close}",
     "point-outlier": "{x}, {y}, {index} de {count}",
     "point-xhl": "{x}, {high} - {low}",
-    "point-xhl-outlier": `{x}, {high} - {low}, con {count, plural, 
-        =0 {Sin valores atípicos} 
-        one {{count} valor atípico} 
+    "point-xhl-outlier": `{x}, {high} - {low}, con {count, plural,
+        =0 {Sin valores atípicos}
+        one {{count} valor atípico}
         other {{count} valores atípicos}
     }`,
 

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -121,6 +121,8 @@ const dictionary: translationDict = {
     "stat-outlier": "Valeur aberrante",
 
     "point-xy": "{x}, {y}",
+    "point-xy-label":
+        "{announcePointLabelFirst, select, true {{label}, {x}, {y}} other {{x}, {y}, {label}}}",
     "point-xohlc": "{x}, {open} - {high} - {low} - {close}",
     "point-outlier": "{x}, {y}, {index} de {count}",
     "point-xhl": "{x}, {high} - {low}",

--- a/src/translations/hmn.ts
+++ b/src/translations/hmn.ts
@@ -112,6 +112,8 @@ const dictionary: translationDict = {
     "stat-outlier": "Tawm txawv",
 
     "point-xy": "{x}, {y}",
+    "point-xy-label":
+        "{announcePointLabelFirst, select, true {{label}, {x}, {y}} other {{x}, {y}, {label}}}",
     "point-xohlc": "{x}, {open} - {high} - {low} - {close}",
     "point-outlier": "{x}, {y}, {index} ntawm {count}",
     "point-xhl": "{x}, {high} - {low}",

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -122,12 +122,14 @@ const dictionary: translationDict = {
     "stat-outlier": "Outlier",
 
     "point-xy": "{x}, {y}",
+    "point-xy-label":
+        "{announcePointLabelFirst, select, true {{label}, {x}, {y}} other {{x}, {y}, {label}}}",
     "point-xohlc": "{x}, {open} - {high} - {low} - {close}",
     "point-outlier": "{x}, {y}, {index} di {count}",
     "point-xhl": "{x}, {high} - {low}",
-    "point-xhl-outlier": `{x}, {high} - {low}, con {count, plural, 
-        =0 {nessun outlier} 
-        one {{count} outlier} 
+    "point-xhl-outlier": `{x}, {high} - {low}, con {count, plural,
+        =0 {nessun outlier}
+        one {{count} outlier}
         other {{count} outlier}
     }`,
 

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -78,6 +78,12 @@ export class TranslationManager {
             code,
             createIntl({
                 locale: code,
+                onError: (...args) => {
+                    // Suppress missing translation errors
+                    if ((args[0].code as string) === "MISSING_DATA") {
+                        return;
+                    }
+                },
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 messages: translations[code]
             })

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -78,12 +78,6 @@ export class TranslationManager {
             code,
             createIntl({
                 locale: code,
-                onError: (...args) => {
-                    // Suppress missing translation errors
-                    if ((args[0].code as string) === "MISSING_DATA") {
-                        return;
-                    }
-                },
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 messages: translations[code]
             })

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,7 @@ export type c2mOptions = {
     hertzes?: number[];
     stack?: boolean;
     root?: null | string;
+    announcePointLabelFirst?: boolean;
     translationCallback?: ({
         language,
         id,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "outDir": "./dist/",
         "removeComments": true,
         "target": "ES2020",
+        "lib": ["ES2021", "DOM"],
         "preserveConstEnums": true,
         "moduleResolution": "Node",
         "types": ["node"],


### PR DESCRIPTION
This is a replacement PR that fixes a failing type change (that didn't need to change)...

This PR addresses a couple of tightly related issues:

* simple x, y data points didn't have a way to provide a custom format, (e.g. a colon instead of a comma, currency format, etc) - other than by passing in a label, which also has constraints.
* In the case of stacked bar-charts the stacked information was dropped with no good way to retrieve it for display

This PR solves both problems, and keeps backwards compatibility with current behavior.
