### PR TITLE
Support mean statistics in box plot data

### DIFF
--- a/examples/anychart.html
+++ b/examples/anychart.html
@@ -28,16 +28,16 @@
   <script>
     anychart.onDocumentReady(function () {
       var data = [
-        {x:"Western Europe", low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53},
-        {x:"North America", low: 7.10, q1: 7.18, median: 7.25, q3: 7.33, high: 7.40},
-        {x:"Australia and New Zealand", low: 7.31, q1: 7.32, median: 7.32, q3: 7.33, high: 7.33},
-        {x:"Middle East and Northern Africa", low: 3.07, q1: 4.78, median: 5.30, q3: 6.30, high: 7.27},
-        {x:"Latin America and Caribbean", low: 4.87, q1: 5.80, median: 6.13, q3: 6.66, high: 7.09, outliers: [4.03]},
-        {x:"Southeastern Asia", low: 3.91, q1: 4.88, median: 5.28, q3: 6.01, high: 6.74},
-        {x:"Central and Eastern Europe", low: 4.22, q1: 5.15, median: 5.49, q3: 5.81, high: 6.60},
-        {x:"Eastern Asia", low: 4.91, q1: 5.30, median: 5.65, q3: 5.90, high: 6.38},
-        {x:"Sub-Saharan Africa", low: 2.91, q1: 3.74, median: 4.13, q3: 4.43, high: 5.44, outliers: [5.648]},
-        {x:"Southern Asia", low: 4.40, q1: 4.41, median: 4.64, q3: 4.96, high: 5.20, outliers: [3.36]}
+        {x:"Western Europe", low: 5.03, q1: 6.36, median: 6.91, mean: 6.89, q3: 7.34, high: 7.53},
+        {x:"North America", low: 7.10, q1: 7.18, median: 7.25, mean: 7.25, q3: 7.33, high: 7.40},
+        {x:"Australia and New Zealand", low: 7.31, q1: 7.32, median: 7.32, mean: 7.32, q3: 7.33, high: 7.33},
+        {x:"Middle East and Northern Africa", low: 3.07, q1: 4.78, median: 5.30, mean: 5.40, q3: 6.30, high: 7.27},
+        {x:"Latin America and Caribbean", low: 4.87, q1: 5.80, median: 6.13, mean: 6.22, q3: 6.66, high: 7.09, outliers: [4.03]},
+        {x:"Southeastern Asia", low: 3.91, q1: 4.88, median: 5.28, mean: 5.25, q3: 6.01, high: 6.74},
+        {x:"Central and Eastern Europe", low: 4.22, q1: 5.15, median: 5.49, mean: 5.50, q3: 5.81, high: 6.60},
+        {x:"Eastern Asia", low: 4.91, q1: 5.30, median: 5.65, mean: 5.62, q3: 5.90, high: 6.38},
+        {x:"Sub-Saharan Africa", low: 2.91, q1: 3.74, median: 4.13, mean: 4.15, q3: 4.43, high: 5.44, outliers: [5.648]},
+        {x:"Southern Asia", low: 4.40, q1: 4.41, median: 4.64, mean: 4.62, q3: 4.96, high: 5.20, outliers: [3.36]}
       ]
 
       // create a chart

--- a/examples/anychart.js
+++ b/examples/anychart.js
@@ -28,27 +28,85 @@ const { err } = c2mChart({
         }
     },
     data: [
-        { x: 0, low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53 },
-        { x: 1, low: 7.1, q1: 7.18, median: 7.25, q3: 7.33, high: 7.4 },
-        { x: 2, low: 7.31, q1: 7.32, median: 7.32, q3: 7.33, high: 7.33 },
-        { x: 3, low: 3.07, q1: 4.78, median: 5.3, q3: 6.3, high: 7.27 },
+        {
+            x: 0,
+            low: 5.03,
+            q1: 6.36,
+            median: 6.91,
+            mean: 6.89,
+            q3: 7.34,
+            high: 7.53
+        },
+        {
+            x: 1,
+            low: 7.1,
+            q1: 7.18,
+            median: 7.25,
+            mean: 7.25,
+            q3: 7.33,
+            high: 7.4
+        },
+        {
+            x: 2,
+            low: 7.31,
+            q1: 7.32,
+            median: 7.32,
+            mean: 7.32,
+            q3: 7.33,
+            high: 7.33
+        },
+        {
+            x: 3,
+            low: 3.07,
+            q1: 4.78,
+            median: 5.3,
+            mean: 5.4,
+            q3: 6.3,
+            high: 7.27
+        },
         {
             x: 4,
             low: 4.87,
             q1: 5.8,
             median: 6.13,
+            mean: 6.22,
             q3: 6.66,
             high: 7.09,
             outlier: [4.03]
         },
-        { x: 5, low: 3.91, q1: 4.88, median: 5.28, q3: 6.01, high: 6.74 },
-        { x: 6, low: 4.22, q1: 5.15, median: 5.49, q3: 5.81, high: 6.6 },
-        { x: 7, low: 4.91, q1: 5.3, median: 5.65, q3: 5.9, high: 6.38 },
+        {
+            x: 5,
+            low: 3.91,
+            q1: 4.88,
+            median: 5.28,
+            mean: 5.25,
+            q3: 6.01,
+            high: 6.74
+        },
+        {
+            x: 6,
+            low: 4.22,
+            q1: 5.15,
+            median: 5.49,
+            mean: 5.5,
+            q3: 5.81,
+            high: 6.6
+        },
+        {
+            x: 7,
+            low: 4.91,
+            q1: 5.3,
+            median: 5.65,
+            mean: 5.62,
+            q3: 5.9,
+            high: 6.38
+        },
         {
             x: 8,
             low: 2.91,
             q1: 3.74,
             median: 4.13,
+            mean: 4.15,
             q3: 4.43,
             high: 5.44,
             outlier: [5.648]
@@ -58,6 +116,7 @@ const { err } = c2mChart({
             low: 4.4,
             q1: 4.41,
             median: 4.64,
+            mean: 4.62,
             q3: 4.96,
             high: 5.2,
             outlier: [3.36, 3]

--- a/src/c2mChart.ts
+++ b/src/c2mChart.ts
@@ -1890,11 +1890,15 @@ export class c2m {
             availableStats[this._metadataByGroup[this._groupIndex].statIndex];
         const current = this._data[this._groupIndex][this._pointIndex];
         if (
-            newStat === "outlier" &&
+            ["mean", "outlier"].includes(newStat) &&
             !(
-                "outlier" in current &&
-                Array.isArray(current.outlier) &&
-                current.outlier.length > 0
+                (newStat === "mean" &&
+                    "mean" in current &&
+                    typeof current.mean === "number") ||
+                (newStat === "outlier" &&
+                    "outlier" in current &&
+                    Array.isArray(current.outlier) &&
+                    current.outlier.length > 0)
             )
         ) {
             this._metadataByGroup[this._groupIndex].statIndex--;
@@ -1951,12 +1955,9 @@ export class c2m {
      * Play all outliers to the right, if there are any
      */
     private _playRightOutlier() {
-        if (
-            !(
-                isBoxDataPoint(this.currentPoint) &&
-                "outlier" in this.currentPoint
-            )
-        ) {
+        if (!(
+            isBoxDataPoint(this.currentPoint) && "outlier" in this.currentPoint
+        )) {
             return;
         }
         const max = this.currentPoint.outlier?.length - 1;
@@ -2294,6 +2295,12 @@ export class c2m {
             isOHLCDataPoint(current) ||
             isHighLowDataPoint(current)
         ) {
+            if (
+                availableStats[statIndex] === "mean" &&
+                (!isBoxDataPoint(current) || typeof current.mean !== "number")
+            ) {
+                statIndex = -1;
+            }
             // Only play a single note, because we've drilled into stats
             if (statIndex >= 0) {
                 const stat = availableStats[statIndex];
@@ -2325,7 +2332,10 @@ export class c2m {
                 if (
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     isUnplayable(current[stat], this._yAxis) ||
-                    stat === "outlier"
+                    stat === "outlier" ||
+                    (stat === "mean" &&
+                        (!isBoxDataPoint(current) ||
+                            typeof current.mean !== "number"))
                 ) {
                     return;
                 }
@@ -2387,6 +2397,11 @@ export class c2m {
             this._flagNewStat = false;
         }
 
+        const currentStat = availableStats[statIndex];
+        const meanIsUnavailable =
+            currentStat === "mean" &&
+            (!isBoxDataPoint(current) || typeof current.mean !== "number");
+
         const point = generatePointDescription({
             translationCallback: (code, evaluators) => {
                 return this._translator.translate(code, evaluators);
@@ -2406,7 +2421,7 @@ export class c2m {
                     ? this._y2Axis
                     : this._yAxis
             }),
-            stat: availableStats[statIndex],
+            ...(meanIsUnavailable ? {} : { stat: currentStat }),
             outlierIndex: this._outlierMode ? this._outlierIndex : null,
             announcePointLabelFirst: this._announcePointLabelFirst
         });

--- a/src/dataPoint.ts
+++ b/src/dataPoint.ts
@@ -131,6 +131,8 @@ export interface BoxDataPoint extends HighLowDataPoint {
     q3: number;
     /** The median */
     median: number;
+    /** The arithmetic mean */
+    mean?: number;
     outlier?: number[];
 }
 

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -119,6 +119,7 @@ const dictionary: translationDict = {
     // For box plots
     "stat-q1": "Q1", // Quartile 1
     "stat-median": "Median",
+    "stat-mean": "Mittelwert",
     "stat-q3": "Q3",
     "stat-outlier": "Ausreisser",
 

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -111,6 +111,7 @@ const dictionary: translationDict = {
     // For box plots
     "stat-q1": "Q1", // Quartile 1
     "stat-median": "Median",
+    "stat-mean": "Mean",
     "stat-q3": "Q3",
     "stat-outlier": "Outlier",
 

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -112,6 +112,7 @@ const dictionary: translationDict = {
     // For box plots
     "stat-q1": "Q1", // Quartile 1
     "stat-median": "Mediana",
+    "stat-mean": "Media",
     "stat-q3": "Q3",
     "stat-outlier": "Valor Atípico",
 

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -117,6 +117,7 @@ const dictionary: translationDict = {
     // For box plots
     "stat-q1": "Q1", // Quartile 1
     "stat-median": "Médiane",
+    "stat-mean": "Moyenne",
     "stat-q3": "Q3",
     "stat-outlier": "Valeur aberrante",
 

--- a/src/translations/hmn.ts
+++ b/src/translations/hmn.ts
@@ -108,6 +108,7 @@ const dictionary: translationDict = {
 
     "stat-q1": "Q1",
     "stat-median": "Nruab nrab",
+    "stat-mean": "Qhov nruab nrab",
     "stat-q3": "Q3",
     "stat-outlier": "Tawm txawv",
 

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -118,6 +118,7 @@ const dictionary: translationDict = {
     // For box plots
     "stat-q1": "Q1", // Quartile 1
     "stat-median": "Mediana",
+    "stat-mean": "Media",
     "stat-q3": "Q3",
     "stat-outlier": "Outlier",
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,6 +176,7 @@ export type StatBundle = {
     q1?: number;
     q3?: number;
     median?: number;
+    mean?: number;
     outlier?: number[];
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -363,7 +363,20 @@ export const calculateMetadataByGroup = (
             // Don't calculate min/max for high/low
             availableStats = ["open", "high", "low", "close"];
         } else if (isBoxDataPoint(row.at(0))) {
-            availableStats = ["high", "q3", "median", "q1", "low", "outlier"];
+            availableStats = [
+                "high",
+                "q3",
+                "median",
+                ...(row.some(
+                    (point) =>
+                        isBoxDataPoint(point) && typeof point.mean === "number"
+                )
+                    ? ["mean"]
+                    : []),
+                "q1",
+                "low",
+                "outlier"
+            ];
         } else if (isHighLowDataPoint(row.at(0))) {
             // Don't calculate min/max for high/low
             availableStats = ["high", "low"];

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -241,6 +241,16 @@ export const validateInputDataRowHomogeneity = (
                 row[nonArrayNumber]
             )}`;
         }
+
+        const nonNumericMean = row.findIndex(
+            (cell: BoxDataPoint) =>
+                "mean" in cell && typeof cell.mean !== "number"
+        );
+        if (nonNumericMean >= 0) {
+            return `At least one box has a non-numeric mean. Box means must be numbers. The box in question is: ${JSON.stringify(
+                row[nonNumericMean]
+            )}`;
+        }
         return "";
     }
     if (isHighLowDataPoint(first)) {

--- a/test/chart_boxplot.test.ts
+++ b/test/chart_boxplot.test.ts
@@ -38,6 +38,7 @@ const data = [
         low: 4.87,
         q1: 5.8,
         median: 6.13,
+        mean: 6.22,
         q3: 6.66,
         high: 7.09,
         outlier: [4.03]
@@ -87,6 +88,7 @@ test("Checking out the outliers", () => {
     expect(err).toBe(null);
 
     mockElement.dispatchEvent(new Event("focus"));
+    audioEngine.reset();
 
     // Confirm that a summary was generated
     expect(mockElementCC.textContent).toEqual(
@@ -102,7 +104,7 @@ test("Checking out the outliers", () => {
         {
             press: { key: "ArrowRight" },
             text: "Latin America and Caribbean, 7.09 - 4.87, with 1 outlier",
-            count: 5
+            count: 6
         },
         {
             press: { key: "ArrowDown" },
@@ -117,6 +119,11 @@ test("Checking out the outliers", () => {
         {
             press: { key: "ArrowDown" },
             text: "Median, Latin America and Caribbean, 6.13",
+            count: 1
+        },
+        {
+            press: { key: "ArrowDown" },
+            text: "Mean, Latin America and Caribbean, 6.22",
             count: 1
         },
         {
@@ -211,6 +218,42 @@ test("Checking out the outliers", () => {
         expect(audioEngine.playCount).toBe(count);
         audioEngine.reset();
     });
+});
+
+test("Mean is skipped for boxes that do not provide it", () => {
+    const mockElement = document.createElement("div");
+    const mockElementCC = document.createElement("div");
+    const { err } = c2mChart({
+        type: "box",
+        data: [data[0], data[1]],
+        element: mockElement,
+        cc: mockElementCC,
+        audioEngine
+    });
+    expect(err).toBe(null);
+
+    mockElement.dispatchEvent(new Event("focus"));
+    mockElement.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight" })
+    );
+    jest.advanceTimersByTime(250);
+    audioEngine.reset();
+
+    ["ArrowDown", "ArrowDown", "ArrowDown", "ArrowDown"].forEach((key) => {
+        mockElement.dispatchEvent(new KeyboardEvent("keydown", { key }));
+        jest.advanceTimersByTime(250);
+        audioEngine.reset();
+    });
+
+    mockElement.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft" })
+    );
+    jest.advanceTimersByTime(250);
+    expect(mockElementCC.lastElementChild?.textContent?.trim()).toBe(
+        "0, 7.53 - 5.03"
+    );
+    expect(audioEngine.playCount).toBe(5);
+    audioEngine.reset();
 });
 
 test("Large number of outliers", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -633,6 +633,7 @@ describe("utils", () => {
                         low: 5.03,
                         q1: 6.36,
                         median: 6.91,
+                        mean: 6.89,
                         q3: 7.34,
                         high: 7.53
                     },
@@ -722,6 +723,7 @@ describe("utils", () => {
                     "high",
                     "q3",
                     "median",
+                    "mean",
                     "q1",
                     "low",
                     "outlier"

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -318,6 +318,23 @@ test("validateInputDataRowHomogeneity", () => {
     ).toBe(
         `At least one box has a non-numeric outlier. Box outliers must be an array of numbers. The box in question is: {"x":2,"low":5.03,"q1":6.36,"median":6.91,"q3":7.34,"high":7.53,"outlier":[5,null]}`
     );
+    expect(
+        validateInputDataRowHomogeneity([
+            { x: 0, low: 5.03, q1: 6.36, median: 6.91, q3: 7.34, high: 7.53 },
+            {
+                x: 1,
+                low: 5.03,
+                q1: 6.36,
+                median: 6.91,
+                q3: 7.34,
+                high: 7.53,
+                // @ts-ignore: Deliberately using invalid data in order to test error handling
+                mean: "6.91"
+            }
+        ])
+    ).toBe(
+        `At least one box has a non-numeric mean. Box means must be numbers. The box in question is: {"x":1,"low":5.03,"q1":6.36,"median":6.91,"q3":7.34,"high":7.53,"mean":"6.91"}`
+    );
 
     // @ts-ignore - deliberately generating error condition
     // Confirm number homogeneity


### PR DESCRIPTION
Fixes #753\n\nAdds optional mean support for box-plot data, including navigation, speech descriptions, sonification, validation, and translations. Mean is skipped for individual box points that do not provide it.\n\nValidation:\n- npm test\n- npm run lint-check\n- npm run build